### PR TITLE
Add force option to skip caching

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -14,7 +14,7 @@ app = typer.Typer(help="Émanet subtitles offline pipeline (CLI étendue)")
 @app.command('offline')
 def offline(url: str = typer.Argument(..., help="URL YouTube de l'épisode"),
            open_vlc: bool = typer.Option(True, help="Ouvrir VLC après génération"),
-           no_cache: bool = typer.Option(False, help="Ignorer le cache et régénérer")):
+           no_cache: bool = typer.Option(False, help="Ignorer le cache (lecture/écriture)")):
     start=time.time()
     with Progress(SpinnerColumn(), *Progress.get_default_columns(), TimeElapsedColumn()) as progress:
         task = progress.add_task("Pipeline", total=None)

--- a/src/offline/pipeline_offline.py
+++ b/src/offline/pipeline_offline.py
@@ -13,25 +13,40 @@ from ..logger import logger
 
 
 def run_offline(url: str, *, force: bool = False) -> Path:
-    """Run the offline pipeline for a single YouTube URL."""
+    """Run the offline pipeline for a single YouTube URL.
+
+    Parameters
+    ----------
+    url: str
+        Youtube URL to process.
+    force: bool, default ``False``
+        When ``True`` the transcription and translation caches are
+        completely bypassed (neither read nor written).
+    """
     audio = download_audio(url)
     norm = normalize(audio)
 
     t_cache = transcription_cache_path(norm)
-    segments = None if force else load_json(t_cache)
-    if segments is None:
+    if force:
         segments = transcribe(norm)
-        save_json(t_cache, segments)
     else:
-        logger.info('cache.hit.transcription', file=str(norm))
+        segments = load_json(t_cache)
+        if segments is None:
+            segments = transcribe(norm)
+            save_json(t_cache, segments)
+        else:
+            logger.info('cache.hit.transcription', file=str(norm))
 
     tr_cache = translation_cache_path(norm)
-    translated = None if force else load_json(tr_cache)
-    if translated is None:
+    if force:
         translated = translate_segments(segments)
-        save_json(tr_cache, translated)
     else:
-        logger.info('cache.hit.translation', file=str(norm))
+        translated = load_json(tr_cache)
+        if translated is None:
+            translated = translate_segments(segments)
+            save_json(tr_cache, translated)
+        else:
+            logger.info('cache.hit.translation', file=str(norm))
     # build srt
     from uuid import uuid4
     out = Path(settings.subs_dir)/f"{uuid4().hex}.srt"

--- a/test/test_run_offline_force.py
+++ b/test/test_run_offline_force.py
@@ -1,0 +1,58 @@
+import pytest
+
+
+def import_pipeline(monkeypatch):
+    import sys, types
+    sys.modules.setdefault('yt_dlp', types.SimpleNamespace(YoutubeDL=lambda *a, **k: None))
+    sys.modules.setdefault('faster_whisper', types.SimpleNamespace(WhisperModel=object))
+    sys.modules.setdefault('transformers', types.SimpleNamespace(AutoTokenizer=object, AutoModelForSeq2SeqLM=object))
+    structlog_mod = types.ModuleType('structlog')
+    structlog_mod.configure = lambda **kw: None
+    structlog_mod.processors = types.SimpleNamespace(TimeStamper=lambda fmt=None: None, add_log_level=lambda *a, **k: None, JSONRenderer=lambda *a, **k: None)
+    structlog_mod.get_logger = lambda: types.SimpleNamespace(info=lambda *a, **k: None, warning=lambda *a, **k: None, error=lambda *a, **k: None)
+    stdlib_mod = types.ModuleType('structlog.stdlib')
+    stdlib_mod.LoggerFactory = object
+    sys.modules.setdefault('structlog', structlog_mod)
+    sys.modules.setdefault('structlog.stdlib', stdlib_mod)
+    config_mod = types.ModuleType('src.config')
+    config_mod.settings = types.SimpleNamespace(subs_dir='subs')
+    sys.modules.setdefault('src.config', config_mod)
+    from src.offline import pipeline_offline as pl
+    return pl
+
+
+def test_run_offline_force(monkeypatch, tmp_path):
+    pl = import_pipeline(monkeypatch)
+    # output directory for SRT
+    monkeypatch.setattr(pl.settings, "subs_dir", str(tmp_path))
+
+    # stub heavy operations
+    monkeypatch.setattr(pl, "download_audio", lambda url: tmp_path / "dl.wav")
+    monkeypatch.setattr(pl, "normalize", lambda p: p)
+    monkeypatch.setattr(pl, "transcribe", lambda p: [{"start": 0.0, "end": 1.0, "text": "hi"}])
+    monkeypatch.setattr(
+        pl, "translate_segments", lambda segs: [{"start": 0.0, "end": 1.0, "text": "hi", "text_fr": "bonjour"}]
+    )
+    monkeypatch.setattr(pl, "build_srt", lambda segs, out: out.write_text("ok") or out)
+
+    # stub cache helpers and record usage
+    monkeypatch.setattr(pl, "transcription_cache_path", lambda p: tmp_path / "t.json")
+    monkeypatch.setattr(pl, "translation_cache_path", lambda p: tmp_path / "tr.json")
+    load_called = []
+    save_called = []
+
+    def fake_load(path):
+        load_called.append(path)
+        return None
+
+    def fake_save(path, data):
+        save_called.append(path)
+
+    monkeypatch.setattr(pl, "load_json", fake_load)
+    monkeypatch.setattr(pl, "save_json", fake_save)
+
+    result = pl.run_offline("http://example.com", force=True)
+
+    assert result.exists()
+    assert load_called == []
+    assert save_called == []


### PR DESCRIPTION
## Summary
- allow skipping cache read/writes in `run_offline`
- adjust CLI help message for `--no-cache`
- test `run_offline(force=True)` with stubs

## Testing
- `PYTHONPATH=. pytest test/test_run_offline_force.py::test_run_offline_force -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError for pydantic, transformers, faster_whisper)*

------
https://chatgpt.com/codex/tasks/task_e_6886624f09908323a091e20676997864