### PR TITLE
Fix tests by adding conftest

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- ensure `pytest` can import the `src` package without installing dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866b9efc6c83238c3e8c0418136e8f