### PR TITLE
Enforce max segment length when merging

### DIFF
--- a/src/offline/transcriber_offline.py
+++ b/src/offline/transcriber_offline.py
@@ -21,17 +21,21 @@ def transcribe(audio_path: Path):
     logger.info('transcribe.start', file=str(audio_path))
     segments, info = model.transcribe(str(audio_path), beam_size=5, vad_filter=True)
     collected = []
-    last_end = None
     for seg in segments:
-        # Merge small gaps
-        if collected and seg.start - collected[-1]['end'] < settings.merge_gap_seconds:
-            collected[-1]['text'] += ' ' + seg.text.strip()
+        seg_text = seg.text.strip()
+        # Merge small gaps when the combined text is not too long
+        if (
+            collected
+            and seg.start - collected[-1]['end'] < settings.merge_gap_seconds
+            and len(collected[-1]['text']) + 1 + len(seg_text) <= settings.max_segment_chars
+        ):
+            collected[-1]['text'] += ' ' + seg_text
             collected[-1]['end'] = seg.end
         else:
             collected.append({
                 'start': float(seg.start),
                 'end': float(seg.end),
-                'text': seg.text.strip()
+                'text': seg_text
             })
     logger.info('transcribe.done', segments=len(collected))
     return collected

--- a/test/test_offline_transcriber.py
+++ b/test/test_offline_transcriber.py
@@ -1,7 +1,59 @@
-import pytest
+import sys, types
+from pathlib import Path
 
-pytest.skip("Need sample audio to test", allow_module_level=True)
+# Stub external modules before importing the module under test
+fw_mod = types.ModuleType("faster_whisper")
+fw_mod.WhisperModel = object
+sys.modules.setdefault("faster_whisper", fw_mod)
+
+config_mod = types.ModuleType("src.config")
+config_mod.settings = types.SimpleNamespace(
+    merge_gap_seconds=0.5,
+    max_segment_chars=10,
+    whisper_model_size="tiny",
+    whisper_device="cpu",
+    whisper_compute_type="int8",
+)
+logger_mod = types.ModuleType("src.logger")
+logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None)
+sys.modules["src.config"] = config_mod
+sys.modules["src.logger"] = logger_mod
+
+import src.offline.transcriber_offline as transcriber
 
 
-def test_transcribe_stub():
-    assert True
+class DummyModel:
+    def __init__(self, segments):
+        self._segments = segments
+
+    def transcribe(self, *a, **k):
+        return self._segments, {}
+
+
+def _run_transcribe(monkeypatch, segments, max_chars):
+    monkeypatch.setattr(transcriber, "get_model", lambda: DummyModel(segments))
+    monkeypatch.setattr(transcriber.settings, "max_segment_chars", max_chars)
+    return transcriber.transcribe(Path("x.wav"))
+
+
+def test_no_merge_when_exceeding_limit(monkeypatch):
+    segs = [
+        types.SimpleNamespace(start=0.0, end=1.0, text="hello"),
+        types.SimpleNamespace(start=1.1, end=2.0, text="world"),
+    ]
+    result = _run_transcribe(monkeypatch, segs, max_chars=9)
+    assert result == [
+        {"start": 0.0, "end": 1.0, "text": "hello"},
+        {"start": 1.1, "end": 2.0, "text": "world"},
+    ]
+
+
+def test_merge_when_within_limit(monkeypatch):
+    segs = [
+        types.SimpleNamespace(start=0.0, end=1.0, text="abc"),
+        types.SimpleNamespace(start=1.1, end=2.0, text="def"),
+    ]
+    result = _run_transcribe(monkeypatch, segs, max_chars=10)
+    assert result == [
+        {"start": 0.0, "end": 2.0, "text": "abc def"},
+    ]


### PR DESCRIPTION
## Summary
- limit segment merge in `transcribe` to avoid exceeding `max_segment_chars`
- add unit tests covering merge logic around this limit

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68866dd5efb08323a8b78725e768761b