### PR TITLE
Fix poetry conflict with tokenizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ VLC s’ouvrira automatiquement (si installé) avec les sous-titres générés d
 
 ## GUI
 ```bash
-python src/gui.py
+python -m src.gui
 ```
 Entrer l’URL, lancer.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ typer = {version="^0.9", extras=["all"]}
 requests = "^2.32.0"
 python-dotenv = "^1.0.1"
 pysrt = "^1.1.2"
-faster-whisper = "^0.10.0"
+faster-whisper = "^1.1.1"
 transformers = "^4.41.0"
 sentencepiece = "^0.1.99"
 sacremoses = "^0.1.1"


### PR DESCRIPTION
## Summary
- bump `faster-whisper` requirement to latest 1.1.x compatible with `transformers`
- update README to run the GUI as a module

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688755a311508323a9a925e7f92de39f