### PR TITLE
Fix Poetry package layout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ license = "MIT"
 description = "Pipeline 100% offline: Whisper (turc) -> FR NLLB, batch, bench, debug avancé."
 authors = ["Votre Nom <vous@example.com>"]
 readme = "README.md"
+packages = [{ include = "src" }]
 
 [tool.poetry.dependencies]
 python = "^3.11"


### PR DESCRIPTION
## Summary
- set packages to use src layout in `pyproject.toml`

## Testing
- `poetry install`
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba1fdae588323960e091f384eeedd