### PR TITLE
Remove unused imports

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -1,6 +1,5 @@
 import typer, subprocess, sys, json, time
 from pathlib import Path
-from typing import List
 from rich.progress import Progress, SpinnerColumn, TimeElapsedColumn
 from .offline.pipeline_offline import run_offline
 from .offline.transcriber_offline import get_model

--- a/src/util/downloader.py
+++ b/src/util/downloader.py
@@ -1,4 +1,4 @@
-import yt_dlp, os, hashlib
+import yt_dlp
 from pathlib import Path
 from ..logger import logger
 from ..config import settings


### PR DESCRIPTION
## Summary
- drop unused imports in downloader and CLI modules
- run flake8 and pytest

## Testing
- `flake8 src/util/downloader.py src/cli.py | head -n 5`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba1fe505083239f626f86e82ff81b