### PR TITLE
Use ctranslate2 to detect CUDA

### DIFF
--- a/src/offline/transcriber_offline.py
+++ b/src/offline/transcriber_offline.py
@@ -1,4 +1,5 @@
 from faster_whisper import WhisperModel
+import ctranslate2
 from pathlib import Path
 from ..config import settings
 from ..logger import logger
@@ -11,8 +12,18 @@ def get_model():
         logger.info('whisper.load', size=settings.whisper_model_size, device=settings.whisper_device)
         _model_singleton = WhisperModel(
             settings.whisper_model_size,
-            device=settings.whisper_device if settings.whisper_device!='auto' else 'cuda' if WhisperModel.is_cuda_available() else 'cpu',
-            compute_type=settings.whisper_compute_type if settings.whisper_compute_type!='auto' else 'int8_float16'
+            device=(
+                settings.whisper_device
+                if settings.whisper_device != 'auto'
+                else 'cuda'
+                if ctranslate2.get_cuda_device_count() > 0
+                else 'cpu'
+            ),
+            compute_type=(
+                settings.whisper_compute_type
+                if settings.whisper_compute_type != 'auto'
+                else 'int8_float16'
+            ),
         )
     return _model_singleton
 

--- a/test/test_offline_transcriber.py
+++ b/test/test_offline_transcriber.py
@@ -6,6 +6,10 @@ fw_mod = types.ModuleType("faster_whisper")
 fw_mod.WhisperModel = object
 sys.modules.setdefault("faster_whisper", fw_mod)
 
+ct_mod = types.ModuleType("ctranslate2")
+ct_mod.get_cuda_device_count = lambda: 0
+sys.modules.setdefault("ctranslate2", ct_mod)
+
 config_mod = types.ModuleType("src.config")
 config_mod.settings = types.SimpleNamespace(
     merge_gap_seconds=0.5,

--- a/test/test_run_offline_force.py
+++ b/test/test_run_offline_force.py
@@ -5,6 +5,7 @@ def import_pipeline(monkeypatch):
     import sys, types
     sys.modules.setdefault('yt_dlp', types.SimpleNamespace(YoutubeDL=lambda *a, **k: None))
     sys.modules.setdefault('faster_whisper', types.SimpleNamespace(WhisperModel=object))
+    sys.modules.setdefault('ctranslate2', types.SimpleNamespace(get_cuda_device_count=lambda: 0))
     sys.modules.setdefault('transformers', types.SimpleNamespace(AutoTokenizer=object, AutoModelForSeq2SeqLM=object))
     structlog_mod = types.ModuleType('structlog')
     structlog_mod.configure = lambda **kw: None


### PR DESCRIPTION
## Summary
- add `ctranslate2` dependency in the offline transcriber
- choose CUDA device using `ctranslate2.get_cuda_device_count()`
- stub `ctranslate2` in unit tests

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688baf0724488323aeffe315047f59a1