### PR TITLE
Handle ffmpeg failures in normalize()

### DIFF
--- a/src/util/audio.py
+++ b/src/util/audio.py
@@ -12,10 +12,11 @@ def normalize(audio_path: Path) -> Path:
         '-ar', '16000', '-ac', '1', '-af', 'loudnorm',
         str(out)
     ]
-    res = subprocess.run(cmd, capture_output=True)
-    if res.returncode != 0:
-        logger.error('normalize.error', stderr=res.stderr.decode())
-        raise RuntimeError('Normalization failed')
+    try:
+        subprocess.run(cmd, capture_output=True, check=True)
+    except subprocess.CalledProcessError as exc:
+        logger.error('normalize.error', stderr=exc.stderr.decode())
+        raise
     logger.info('normalize.done', out=str(out))
     return out
 

--- a/test/test_audio.py
+++ b/test/test_audio.py
@@ -1,0 +1,30 @@
+import sys, types, subprocess
+import pytest
+from pathlib import Path
+
+# stub logger and config before importing the module under test
+logger_mod = types.ModuleType("src.logger")
+logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None, error=lambda *a, **k: None)
+sys.modules["src.logger"] = logger_mod
+
+config_mod = types.ModuleType("src.config")
+config_mod.settings = types.SimpleNamespace(audio_dir="x")
+sys.modules["src.config"] = config_mod
+
+import src.util.audio as audio
+
+
+def test_normalize_error(monkeypatch, tmp_path):
+    stderr_calls = []
+    monkeypatch.setattr(audio.logger, "error", lambda *a, **k: stderr_calls.append(k.get("stderr")))
+    monkeypatch.setattr(audio.settings, "audio_dir", str(tmp_path))
+
+    def fake_run(cmd, capture_output=True, check=True):
+        raise subprocess.CalledProcessError(1, cmd, stderr=b"fail")
+
+    monkeypatch.setattr(audio.subprocess, "run", fake_run)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        audio.normalize(tmp_path / "in.wav")
+
+    assert stderr_calls == ["fail"]


### PR DESCRIPTION
## Summary
- raise `CalledProcessError` from `normalize()` and log ffmpeg stderr
- add regression test for error handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688baf080bec8323a0f779213e846313