### PR TITLE
Fix semicolon-separated statements

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -29,7 +29,8 @@ def offline(url: str = typer.Argument(..., help="URL YouTube de l'épisode"),
 
 @app.command('prewarm')
 def prewarm():
-    get_model(); get_translator()
+    get_model()
+    get_translator()
     typer.echo("Modèles chargés en mémoire.")
 
 @app.command('inspect-cache')
@@ -55,7 +56,7 @@ def batch(urls_file: Path = typer.Argument(..., help="Fichier texte: 1 URL par l
         try:
             return u, str(run_offline(u))
         except Exception as e:
-            return u, f"ERREUR: {e}";
+            return u, f"ERREUR: {e}"
     results=[]
     if parallel>1:
         with concurrent.futures.ProcessPoolExecutor(max_workers=parallel) as ex:
@@ -64,7 +65,9 @@ def batch(urls_file: Path = typer.Argument(..., help="Fichier texte: 1 URL par l
                 typer.echo(f"→ {r[0]} => {r[1]}")
     else:
         for u in urls:
-            r=worker(u); results.append(r); typer.echo(f"→ {r[0]} => {r[1]}")
+            r = worker(u)
+            results.append(r)
+            typer.echo(f"→ {r[0]} => {r[1]}")
     if open_vlc:
         for _, srt in results:
             if srt.endswith('.srt'):

--- a/src/util/audio.py
+++ b/src/util/audio.py
@@ -4,7 +4,8 @@ from ..logger import logger
 from ..config import settings
 
 def normalize(audio_path: Path) -> Path:
-    norm_dir = Path(settings.audio_dir); norm_dir.mkdir(parents=True, exist_ok=True)
+    norm_dir = Path(settings.audio_dir)
+    norm_dir.mkdir(parents=True, exist_ok=True)
     out = norm_dir / (audio_path.stem + '_norm.wav')
     logger.info('normalize.start', src=str(audio_path))
     cmd = [


### PR DESCRIPTION
## Summary
- split statements previously joined by semicolons in the CLI and audio helper
- rerun flake8

## Testing
- `flake8`

------
https://chatgpt.com/codex/tasks/task_e_688bb60d15fc8323891e008292932708