### PR TITLE
Fix cli import style

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -16,6 +16,7 @@ from .offline.cache import (
 )
 from .logger import logger
 
+
 app = typer.Typer(help="Émanet subtitles offline pipeline (CLI étendue)")
 
 


### PR DESCRIPTION
## Summary
- adjust spacing after imports in src/cli.py

## Testing
- `flake8 src/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_688bddf543548323a5a9183eab027a3f