### PR TITLE
Add remote debugging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ cp .env.example .env
 ## Utilisation CLI
 ```bash
 emanet-subtitles offline --url https://www.youtube.com/watch?v=VIDEO_ID
+# Pour activer un serveur debugpy:
+emanet-subtitles offline --url https://youtu.be/ID --debug
 ```
 VLC s’ouvrira automatiquement (si installé) avec les sous-titres générés dans `subs/`.
 
@@ -35,7 +37,7 @@ VLC s’ouvrira automatiquement (si installé) avec les sous-titres générés d
 ```bash
 python -m src.gui
 ```
-Entrer l’URL, lancer.
+Entrer l’URL, lancer. Pour activer le débogage distant, cochez "Debug" avant d'exécuter.
 
 ## Caching
 - Transcription : `cache/transcription/<hash>.json`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ tqdm = "^4.66.0"
 rich = "^13.7.1"
 uvicorn = "^0.27.0"
 fastapi = "^0.110.0"
+debugpy = "^1.8.1"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.0"

--- a/src/cli.py
+++ b/src/cli.py
@@ -27,7 +27,15 @@ def offline(
     no_cache: bool = typer.Option(
         False, help="Ignorer le cache (lecture/écriture)"
     ),
+    debug: bool = typer.Option(False, help="Activer le serveur debugpy"),
 ) -> None:
+    if debug:
+        from . import debug as debug_module
+
+        try:
+            debug_module.start()
+        except Exception as e:  # pragma: no cover - debug startup errors
+            typer.secho(f"Erreur démarrage debug: {e}", fg="red")
     start = time.time()
     with Progress(
         SpinnerColumn(),
@@ -35,8 +43,14 @@ def offline(
         TimeElapsedColumn(),
     ) as progress:
         task = progress.add_task("Pipeline", total=None)
-        srt = run_offline(url, force=no_cache)
-        progress.update(task, description="Terminé")
+        try:
+            srt = run_offline(url, force=no_cache)
+            progress.update(task, description="Terminé")
+        except Exception as e:
+            progress.update(task, description="ERREUR")
+            typer.secho(f"Erreur: {e}", fg="red")
+            logger.error("pipeline.error", error=str(e))
+            raise typer.Exit(1)
     typer.echo(f"Sous-titres générés: {srt} (en {time.time() - start:.1f}s)")
     if open_vlc:
         try:

--- a/src/debug.py
+++ b/src/debug.py
@@ -1,0 +1,11 @@
+"""Helpers to enable remote debugging with debugpy."""
+from __future__ import annotations
+
+import debugpy
+
+
+def start(port: int = 5678) -> None:
+    """Start a debugpy server and wait for a client to attach."""
+    debugpy.listen(("0.0.0.0", port))
+    print(f"debugpy listening on {port}; waiting for client...", flush=True)
+    debugpy.wait_for_client()

--- a/src/gui.py
+++ b/src/gui.py
@@ -16,6 +16,10 @@ class App:
         tk.Label(root, text="Episode URL:").grid(row=0, column=0, sticky="e")
         self.url_entry = tk.Entry(root, width=70)
         self.url_entry.grid(row=0, column=1, columnspan=2)
+        self.debug_var = tk.BooleanVar(value=False)
+        tk.Checkbutton(root, text="Debug", variable=self.debug_var).grid(
+            row=0, column=3, sticky="w"
+        )
         tk.Button(
             root,
             text="Run",
@@ -76,6 +80,13 @@ class App:
     def _do_run(self, url: str) -> None:
         t0 = time.time()
         try:
+            if self.debug_var.get():
+                from . import debug as debug_module
+
+                try:
+                    debug_module.start()
+                except Exception as e:  # pragma: no cover
+                    self.append(f"Erreur démarrage debug: {e}")
             self.append("Téléchargement / Transcription / Traduction...")
             srt = run_offline(url)
             self.append(
@@ -87,6 +98,7 @@ class App:
                 self.append("VLC non trouvé.")
         except Exception as e:  # pragma: no cover - runtime errors
             self.append(f"ERREUR: {e}")
+            messagebox.showerror("Erreur", str(e))
 
 
 if __name__ == "__main__":

--- a/test/test_cli_debug.py
+++ b/test/test_cli_debug.py
@@ -1,0 +1,79 @@
+from typer.testing import CliRunner
+import types
+import sys
+
+
+def test_offline_debug(monkeypatch):
+    # Setup minimal stubs before importing CLI
+    logger_mod = types.ModuleType("src.logger")
+    logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None)
+    config_mod = types.ModuleType("src.config")
+    config_mod.settings = types.SimpleNamespace(
+        subs_dir="x",
+        max_line_chars=42,
+    )
+    monkeypatch.setitem(sys.modules, "src.logger", logger_mod)
+    monkeypatch.setitem(sys.modules, "src.config", config_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "yt_dlp",
+        types.SimpleNamespace(YoutubeDL=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "faster_whisper",
+        types.SimpleNamespace(WhisperModel=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ctranslate2",
+        types.SimpleNamespace(get_cuda_device_count=lambda: 0),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        types.SimpleNamespace(
+            AutoTokenizer=object,
+            AutoModelForSeq2SeqLM=object,
+        ),
+    )
+    monkeypatch.setitem(sys.modules, "debugpy", types.ModuleType("debugpy"))
+
+    import importlib
+    cli = importlib.import_module("src.cli")
+
+    called = []
+    monkeypatch.setattr(cli, "run_offline", lambda url, force=False: "x.srt")
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda *a, **k: None)
+
+    class DummyProgress:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        @staticmethod
+        def get_default_columns():
+            return []
+
+        def add_task(self, *a, **kw):
+            return 0
+
+        def update(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(cli, "Progress", DummyProgress)
+    import src.debug as debug_module
+    monkeypatch.setattr(debug_module, "start", lambda: called.append(True))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["offline", "http://x", "--debug", "--no-cache", "--no-open-vlc"],
+    )
+    assert result.exit_code == 0
+    assert called == [True]

--- a/test/test_cli_error.py
+++ b/test/test_cli_error.py
@@ -1,0 +1,80 @@
+from typer.testing import CliRunner
+import types
+import sys
+
+
+def test_offline_error(monkeypatch):
+    logger_mod = types.ModuleType("src.logger")
+    logger_mod.logger = types.SimpleNamespace(
+        info=lambda *a, **k: None,
+        error=lambda *a, **k: None,
+    )
+    config_mod = types.ModuleType("src.config")
+    config_mod.settings = types.SimpleNamespace(
+        subs_dir="x",
+        max_line_chars=42,
+    )
+    monkeypatch.setitem(sys.modules, "src.logger", logger_mod)
+    monkeypatch.setitem(sys.modules, "src.config", config_mod)
+    monkeypatch.setitem(
+        sys.modules,
+        "yt_dlp",
+        types.SimpleNamespace(YoutubeDL=lambda *a, **k: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "faster_whisper",
+        types.SimpleNamespace(WhisperModel=object),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "ctranslate2",
+        types.SimpleNamespace(get_cuda_device_count=lambda: 0),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        types.SimpleNamespace(
+            AutoTokenizer=object,
+            AutoModelForSeq2SeqLM=object,
+        ),
+    )
+    import importlib
+
+    cli = importlib.import_module("src.cli")
+
+    def fail(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(cli, "run_offline", fail)
+    monkeypatch.setattr(cli.subprocess, "Popen", lambda *a, **k: None)
+
+    class DummyProgress:
+        def __init__(self, *a, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            pass
+
+        @staticmethod
+        def get_default_columns():
+            return []
+
+        def add_task(self, *a, **kw):
+            return 0
+
+        def update(self, *a, **kw):
+            pass
+
+    monkeypatch.setattr(cli, "Progress", DummyProgress)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli.app,
+        ["offline", "http://x", "--no-open-vlc"],
+    )
+    assert result.exit_code == 1
+    assert "Erreur: boom" in result.stdout

--- a/test/test_gui_debug.py
+++ b/test/test_gui_debug.py
@@ -1,0 +1,53 @@
+import types
+import sys
+
+
+def test_gui_debug(monkeypatch):
+    import importlib
+
+    yt_mod = types.ModuleType("yt_dlp")
+    yt_mod.YoutubeDL = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "yt_dlp", yt_mod)
+    fw_mod = types.ModuleType("faster_whisper")
+    fw_mod.WhisperModel = object
+    monkeypatch.setitem(sys.modules, "faster_whisper", fw_mod)
+    ct_mod = types.ModuleType("ctranslate2")
+    ct_mod.get_cuda_device_count = lambda: 0
+    monkeypatch.setitem(sys.modules, "ctranslate2", ct_mod)
+    tr_mod = types.ModuleType("transformers")
+    tr_mod.AutoTokenizer = object
+    tr_mod.AutoModelForSeq2SeqLM = object
+    monkeypatch.setitem(sys.modules, "transformers", tr_mod)
+    config_mod = types.ModuleType("src.config")
+    config_mod.settings = types.SimpleNamespace(
+        subs_dir="x",
+        max_line_chars=42,
+    )
+    monkeypatch.setitem(sys.modules, "src.config", config_mod)
+    logger_mod = types.ModuleType("src.logger")
+    logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "src.logger", logger_mod)
+
+    called = []
+
+    def start():
+        print("start called")
+        called.append(True)
+
+    stub = types.SimpleNamespace(start=start)
+    monkeypatch.setitem(sys.modules, "src.debug", stub)
+    if "src" in sys.modules:
+        setattr(sys.modules["src"], "debug", stub)
+
+    gui = importlib.import_module("src.gui")
+
+    app = object.__new__(gui.App)
+    app.append = lambda *a: None
+    app.debug_var = types.SimpleNamespace(get=lambda: True)
+
+    monkeypatch.setattr(gui, "run_offline", lambda url: "x.srt")
+    monkeypatch.setattr(gui.subprocess, "Popen", lambda *a, **k: None)
+    monkeypatch.setattr(gui.messagebox, "showerror", lambda *a, **k: None)
+
+    app._do_run("http://x")
+    assert called == [True]


### PR DESCRIPTION
## Summary
- integrate debugpy as a dependency
- add debug option in CLI to start a debugpy server
- document debug usage in README
- provide helper module for debugpy startup
- add tests for the new debug option
- integrate debug option in GUI
- improve error handling in CLI and GUI
- add tests for CLI errors and GUI debugging

## Testing
- `flake8 src test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688be6d94d148323891522e0b2da2b61