### PR TITLE
Fix compute type fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Supprimer ces fichiers pour forcer une régénération.
 
 ## Optimisation
 - GPU : si CUDA dispo, mettre `WHISPER_DEVICE=cuda` et `WHISPER_COMPUTE_TYPE=float16`.
-- CPU : garder `auto` + quantization par défaut (`int8_float16`).
+ - CPU : garder `WHISPER_COMPUTE_TYPE=auto` pour utiliser la quantification `int8`.
 
 ## Tests
 ```bash

--- a/src/offline/transcriber_offline.py
+++ b/src/offline/transcriber_offline.py
@@ -27,7 +27,7 @@ def get_model():
             compute_type=(
                 settings.whisper_compute_type
                 if settings.whisper_compute_type != 'auto'
-                else 'int8_float16'
+                else 'int8'
             ),
         )
     return _model_singleton


### PR DESCRIPTION
## Summary
- default to safer 'int8' compute type for Whisper
- clarify README optimization instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688befed5cc48323889b96458ac05449