### PR TITLE
Switch to Voxtral and Mistral models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,9 @@
 # Mode 100% OFFLINE (pas d'API distante)
-# Modèle Whisper local via faster-whisper
-WHISPER_MODEL_SIZE=small
-WHISPER_DEVICE=auto            # auto / cpu / cuda
-WHISPER_COMPUTE_TYPE=auto      # auto / int8 / int8_float16 / float16 / float32
-# Modèle NLLB pour traduction turc -> français
-# Choisir la taille 600M ou 1.3B (peut être surchargé via NLLB_MODEL)
-NLLB_MODEL_SIZE=600M
+# Modèle Voxtral pour la transcription
+VOXTRAL_MODEL=mistralai/Voxtral-Small-24B-2507
+VOXTRAL_DEVICE=auto            # auto / cpu / cuda
+# Modèle Mistral pour la traduction turc -> français
+MISTRAL_MODEL=mistralai/mistral-medium-2505
 # Limites & perf
 MAX_SEGMENT_CHARS=90           # wrap des lignes SRT
 MAX_LINE_CHARS=42

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
+
+# Install system deps
+RUN apt-get update && apt-get install -y ffmpeg git && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN apt-get update && apt-get install -y python3-pip && rm -rf /var/lib/apt/lists/*
+RUN pip install --upgrade pip && pip install poetry
+RUN poetry config virtualenvs.create false
+RUN poetry install --without dev
+
+COPY . .
+
+ENTRYPOINT ["emanet-subtitles"]
+CMD ["offline"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Émanet Subtitles – Version 100% Offline
 
 Cette version supprime toute dépendance aux APIs distantes :
-- **Transcription** locale via *faster-whisper* (modèle Whisper).
-- **Traduction** locale via *NLLB 200 distilled* (Turc → Français).
+- **Transcription** locale via *mistralai/Voxtral-Small-24B-2507*.
+- **Traduction** locale via *mistralai/mistral-medium-2505* (Turc → Français).
 - **Téléchargement** YouTube avec *yt-dlp*.
 - **Génération** directe des SRT à partir des timestamps Whisper (fusion adaptative des segments).
 - **Cache** SHA256 pour éviter de retraiter un même épisode.
@@ -22,7 +22,7 @@ paquets système comme `cmake` pour compiler `sentencepiece`.
 ## Configuration (optionnelle)
 ```bash
 cp .env.example .env
-# ajustez WHISPER_MODEL_SIZE, NLLB_MODEL_SIZE, etc.
+# ajustez VOXTRAL_MODEL et MISTRAL_MODEL si besoin
 ```
 
 ## Utilisation CLI
@@ -45,18 +45,25 @@ Entrer l’URL, lancer. Pour activer le débogage distant, cochez "Debug" avant 
 Supprimer ces fichiers pour forcer une régénération.
 
 ## Choix de modèles
-- Whisper : changer `WHISPER_MODEL_SIZE` (`tiny`, `base`, `small`, `medium`, `large-v3`).
-- Traduction : variable `NLLB_MODEL_SIZE` (`600M` ou `1.3B`).
+- STT : variable `VOXTRAL_MODEL` (par défaut Voxtral Small).
+- LLM  : variable `MISTRAL_MODEL` (par défaut Mistral Medium 2505).
 
 ## Optimisation
-- GPU : si CUDA dispo, mettre `WHISPER_DEVICE=cuda` et `WHISPER_COMPUTE_TYPE=float16`.
- - CPU : garder `WHISPER_COMPUTE_TYPE=auto` pour utiliser la quantification `int8`.
+- GPU : si CUDA dispo, mettre `VOXTRAL_DEVICE=cuda` pour accélérer la transcription.
 
 ## Tests
 ```bash
 poetry run pytest -q
 ```
 (Certains tests sont marqués `skip` car ils nécessitent un vrai média.)
+
+## Déploiement Runpod
+Une image Docker est fournie pour exécuter le pipeline sur Runpod.io :
+
+```bash
+docker build -t emanet-runpod .
+# puis lancer avec les volumes nécessaires
+```
 
 ## Licence
 MIT.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ typer = {version="^0.9", extras=["all"]}
 requests = "^2.32.0"
 python-dotenv = "^1.0.1"
 pysrt = "^1.1.2"
-faster-whisper = "^1.1.1"
 transformers = "^4.41.0"
 sentencepiece = "^0.1.99"
 sacremoses = "^0.1.1"

--- a/src/config.py
+++ b/src/config.py
@@ -1,13 +1,14 @@
-from typing import Optional
-from pydantic import BaseSettings, Field, validator
+from pydantic import BaseSettings, Field
 
 
 class Settings(BaseSettings):
-    whisper_model_size: str = Field("small", env="WHISPER_MODEL_SIZE")
-    whisper_device: str = Field("auto", env="WHISPER_DEVICE")
-    whisper_compute_type: str = Field("auto", env="WHISPER_COMPUTE_TYPE")
-    nllb_model_size: str = Field("600M", env="NLLB_MODEL_SIZE")
-    nllb_model: Optional[str] = Field(None, env="NLLB_MODEL")
+    voxtral_model: str = Field(
+        "mistralai/Voxtral-Small-24B-2507", env="VOXTRAL_MODEL"
+    )
+    voxtral_device: str = Field("auto", env="VOXTRAL_DEVICE")
+    mistral_model: str = Field(
+        "mistralai/mistral-medium-2505", env="MISTRAL_MODEL"
+    )
     max_segment_chars: int = Field(90, env="MAX_SEGMENT_CHARS")
     max_line_chars: int = Field(42, env="MAX_LINE_CHARS")
     merge_gap_seconds: float = Field(0.4, env="MERGE_GAP_SECONDS")
@@ -16,12 +17,6 @@ class Settings(BaseSettings):
     subs_dir: str = Field("subs", env="SUBS_DIR")
     audio_dir: str = Field("audio", env="AUDIO_DIR")
 
-    @validator("nllb_model", pre=True, always=True)
-    def set_nllb_model(cls, v, values):
-        if v:
-            return v
-        size = values.get("nllb_model_size", "600M")
-        return f"facebook/nllb-200-distilled-{size}"
 
     class Config:
         env_file = ".env"

--- a/src/offline/transcriber_offline.py
+++ b/src/offline/transcriber_offline.py
@@ -1,5 +1,4 @@
-from faster_whisper import WhisperModel
-import ctranslate2
+from transformers import pipeline
 from pathlib import Path
 from ..config import settings
 from ..logger import logger
@@ -11,24 +10,16 @@ def get_model():
     global _model_singleton
     if _model_singleton is None:
         logger.info(
-            'whisper.load',
-            size=settings.whisper_model_size,
-            device=settings.whisper_device,
+            'voxtral.load',
+            model=settings.voxtral_model,
+            device=settings.voxtral_device,
         )
-        _model_singleton = WhisperModel(
-            settings.whisper_model_size,
-            device=(
-                settings.whisper_device
-                if settings.whisper_device != 'auto'
-                else 'cuda'
-                if ctranslate2.get_cuda_device_count() > 0
-                else 'cpu'
-            ),
-            compute_type=(
-                settings.whisper_compute_type
-                if settings.whisper_compute_type != 'auto'
-                else 'int8'
-            ),
+        device = 0 if settings.voxtral_device == 'cuda' else -1
+        _model_singleton = pipeline(
+            'automatic-speech-recognition',
+            model=settings.voxtral_model,
+            device=device,
+            return_timestamps=True,
         )
     return _model_singleton
 
@@ -36,28 +27,20 @@ def get_model():
 def transcribe(audio_path: Path):
     model = get_model()
     logger.info('transcribe.start', file=str(audio_path))
-    segments, info = model.transcribe(
-        str(audio_path),
-        beam_size=5,
-        vad_filter=True,
-    )
-    collected = []
-    for seg in segments:
-        seg_text = seg.text.strip()
-        # Merge small gaps when the combined text is not too long
+    result = model(str(audio_path))
+    segments = []
+    for chunk in result.get('chunks', []):
+        seg_text = chunk['text'].strip()
+        start, end = chunk['timestamp']
         if (
-            collected
-            and seg.start - collected[-1]['end'] < settings.merge_gap_seconds
-            and len(collected[-1]['text']) + 1 + len(seg_text)
+            segments
+            and start - segments[-1]['end'] < settings.merge_gap_seconds
+            and len(segments[-1]['text']) + 1 + len(seg_text)
             <= settings.max_segment_chars
         ):
-            collected[-1]['text'] += ' ' + seg_text
-            collected[-1]['end'] = seg.end
+            segments[-1]['text'] += ' ' + seg_text
+            segments[-1]['end'] = end
         else:
-            collected.append({
-                'start': float(seg.start),
-                'end': float(seg.end),
-                'text': seg_text
-            })
-    logger.info('transcribe.done', segments=len(collected))
-    return collected
+            segments.append({'start': float(start), 'end': float(end), 'text': seg_text})
+    logger.info('transcribe.done', segments=len(segments))
+    return segments

--- a/src/offline/translator_offline.py
+++ b/src/offline/translator_offline.py
@@ -1,4 +1,4 @@
-from transformers import AutoTokenizer, AutoModelForSeq2SeqLM
+from transformers import AutoTokenizer, AutoModelForCausalLM
 
 try:
     import torch
@@ -15,8 +15,8 @@ _model = None
 def get_translator():
     global _tok, _model
     if _tok is None:
-        logger.info("nllb.load", model=settings.nllb_model)
-        _tok = AutoTokenizer.from_pretrained(settings.nllb_model)
+        logger.info("mistral.load", model=settings.mistral_model)
+        _tok = AutoTokenizer.from_pretrained(settings.mistral_model)
         quant_args = {}
         # Prefer 8-bit quantization if bitsandbytes is available
         try:
@@ -25,8 +25,8 @@ def get_translator():
         except Exception:
             if torch is not None:
                 quant_args["torch_dtype"] = torch.float16
-        _model = AutoModelForSeq2SeqLM.from_pretrained(
-            settings.nllb_model,
+        _model = AutoModelForCausalLM.from_pretrained(
+            settings.mistral_model,
             device_map="auto",
             **quant_args,
         )
@@ -38,26 +38,14 @@ def translate_segments(segments):
         return []
     tok, mdl = get_translator()
     out = []
-    batch = []
-    max_batch_chars = 1200
-
-    def flush():
-        if not batch:
-            return
-        texts = [s["text"] for s in batch]
-        inputs = tok(texts, return_tensors="pt", padding=True, truncation=True)
-        gen = mdl.generate(**inputs, max_length=512)
-        decoded = tok.batch_decode(gen, skip_special_tokens=True)
-        for src, tgt in zip(batch, decoded):
-            out.append({**src, "text_fr": tgt})
-        batch.clear()
-
     for seg in segments:
-        if (
-            sum(len(s["text"]) for s in batch) + len(seg["text"])
-            > max_batch_chars
-        ):
-            flush()
-        batch.append(seg)
-    flush()
+        prompt = (
+            "Traduire le texte suivant du turc vers le français:\n"
+            f"{seg['text']}\n"
+            "Traduction:"
+        )
+        inputs = tok(prompt, return_tensors="pt").to(mdl.device)
+        gen = mdl.generate(**inputs, max_new_tokens=256)
+        text_fr = tok.decode(gen[0], skip_special_tokens=True)
+        out.append({**seg, "text_fr": text_fr.strip()})
     return out

--- a/test/test_cli_debug.py
+++ b/test/test_cli_debug.py
@@ -21,20 +21,11 @@ def test_offline_debug(monkeypatch):
     )
     monkeypatch.setitem(
         sys.modules,
-        "faster_whisper",
-        types.SimpleNamespace(WhisperModel=object),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "ctranslate2",
-        types.SimpleNamespace(get_cuda_device_count=lambda: 0),
-    )
-    monkeypatch.setitem(
-        sys.modules,
         "transformers",
         types.SimpleNamespace(
+            pipeline=object,
             AutoTokenizer=object,
-            AutoModelForSeq2SeqLM=object,
+            AutoModelForCausalLM=object,
         ),
     )
     monkeypatch.setitem(sys.modules, "debugpy", types.ModuleType("debugpy"))

--- a/test/test_cli_error.py
+++ b/test/test_cli_error.py
@@ -23,20 +23,11 @@ def test_offline_error(monkeypatch):
     )
     monkeypatch.setitem(
         sys.modules,
-        "faster_whisper",
-        types.SimpleNamespace(WhisperModel=object),
-    )
-    monkeypatch.setitem(
-        sys.modules,
-        "ctranslate2",
-        types.SimpleNamespace(get_cuda_device_count=lambda: 0),
-    )
-    monkeypatch.setitem(
-        sys.modules,
         "transformers",
         types.SimpleNamespace(
+            pipeline=object,
             AutoTokenizer=object,
-            AutoModelForSeq2SeqLM=object,
+            AutoModelForCausalLM=object,
         ),
     )
     import importlib

--- a/test/test_gui_debug.py
+++ b/test/test_gui_debug.py
@@ -8,15 +8,10 @@ def test_gui_debug(monkeypatch):
     yt_mod = types.ModuleType("yt_dlp")
     yt_mod.YoutubeDL = lambda *a, **k: None
     monkeypatch.setitem(sys.modules, "yt_dlp", yt_mod)
-    fw_mod = types.ModuleType("faster_whisper")
-    fw_mod.WhisperModel = object
-    monkeypatch.setitem(sys.modules, "faster_whisper", fw_mod)
-    ct_mod = types.ModuleType("ctranslate2")
-    ct_mod.get_cuda_device_count = lambda: 0
-    monkeypatch.setitem(sys.modules, "ctranslate2", ct_mod)
     tr_mod = types.ModuleType("transformers")
+    tr_mod.pipeline = object
     tr_mod.AutoTokenizer = object
-    tr_mod.AutoModelForSeq2SeqLM = object
+    tr_mod.AutoModelForCausalLM = object
     monkeypatch.setitem(sys.modules, "transformers", tr_mod)
     config_mod = types.ModuleType("src.config")
     config_mod.settings = types.SimpleNamespace(

--- a/test/test_offline_transcriber.py
+++ b/test/test_offline_transcriber.py
@@ -3,21 +3,16 @@ import types
 from pathlib import Path
 
 # Stub external modules before importing the module under test
-fw_mod = types.ModuleType("faster_whisper")
-fw_mod.WhisperModel = object
-sys.modules.setdefault("faster_whisper", fw_mod)
-
-ct_mod = types.ModuleType("ctranslate2")
-ct_mod.get_cuda_device_count = lambda: 0
-sys.modules.setdefault("ctranslate2", ct_mod)
+trans_mod = types.ModuleType("transformers")
+trans_mod.pipeline = object
+sys.modules.setdefault("transformers", trans_mod)
 
 config_mod = types.ModuleType("src.config")
 config_mod.settings = types.SimpleNamespace(
     merge_gap_seconds=0.5,
     max_segment_chars=10,
-    whisper_model_size="tiny",
-    whisper_device="cpu",
-    whisper_compute_type="int8",
+    voxtral_model="x",
+    voxtral_device="cpu",
 )
 logger_mod = types.ModuleType("src.logger")
 logger_mod.logger = types.SimpleNamespace(info=lambda *a, **k: None)
@@ -27,16 +22,18 @@ sys.modules["src.logger"] = logger_mod
 import src.offline.transcriber_offline as transcriber  # noqa: E402
 
 
-class DummyModel:
+class DummyPipeline:
     def __init__(self, segments):
         self._segments = segments
 
-    def transcribe(self, *a, **k):
-        return self._segments, {}
+    def __call__(self, *a, **k):
+        return {"chunks": [
+            {"text": s.text, "timestamp": (s.start, s.end)} for s in self._segments
+        ]}
 
 
 def _run_transcribe(monkeypatch, segments, max_chars):
-    monkeypatch.setattr(transcriber, "get_model", lambda: DummyModel(segments))
+    monkeypatch.setattr(transcriber, "get_model", lambda: DummyPipeline(segments))
     monkeypatch.setattr(transcriber.settings, "max_segment_chars", max_chars)
     return transcriber.transcribe(Path("x.wav"))
 

--- a/test/test_offline_translator.py
+++ b/test/test_offline_translator.py
@@ -3,7 +3,7 @@ import types
 
 trans_mod = types.ModuleType("transformers")
 trans_mod.AutoTokenizer = object
-trans_mod.AutoModelForSeq2SeqLM = object
+trans_mod.AutoModelForCausalLM = object
 sys.modules["transformers"] = trans_mod
 
 config_mod = types.ModuleType("src.config")

--- a/test/test_run_offline_cache.py
+++ b/test/test_run_offline_cache.py
@@ -7,18 +7,11 @@ def import_pipeline(monkeypatch):
         types.SimpleNamespace(YoutubeDL=lambda *a, **k: None),
     )
     sys.modules.setdefault(
-        'faster_whisper',
-        types.SimpleNamespace(WhisperModel=object),
-    )
-    sys.modules.setdefault(
-        'ctranslate2',
-        types.SimpleNamespace(get_cuda_device_count=lambda: 0),
-    )
-    sys.modules.setdefault(
         'transformers',
         types.SimpleNamespace(
+            pipeline=object,
             AutoTokenizer=object,
-            AutoModelForSeq2SeqLM=object,
+            AutoModelForCausalLM=object,
         ),
     )
     structlog_mod = types.ModuleType('structlog')

--- a/test/test_run_offline_force.py
+++ b/test/test_run_offline_force.py
@@ -6,16 +6,11 @@ def import_pipeline(monkeypatch):
         'yt_dlp', types.SimpleNamespace(YoutubeDL=lambda *a, **k: None)
     )
     sys.modules.setdefault(
-        'faster_whisper', types.SimpleNamespace(WhisperModel=object)
-    )
-    sys.modules.setdefault(
-        'ctranslate2', types.SimpleNamespace(get_cuda_device_count=lambda: 0)
-    )
-    sys.modules.setdefault(
         'transformers',
         types.SimpleNamespace(
+            pipeline=object,
             AutoTokenizer=object,
-            AutoModelForSeq2SeqLM=object,
+            AutoModelForCausalLM=object,
         ),
     )
     structlog_mod = types.ModuleType('structlog')


### PR DESCRIPTION
## Summary
- migrate from Whisper/NLLB to Mistral's Voxtral and Mistral Medium models
- adjust configuration and environment example
- update transcriber and translator implementations
- update tests for new dependencies
- add Dockerfile for runpod deployment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c94a86b08832384fb6f8a4259453e